### PR TITLE
Prevent duplicate header menu event bindings

### DIFF
--- a/css/header.css
+++ b/css/header.css
@@ -178,6 +178,11 @@ header {
     padding-top: 15px;
     margin-top: 10px;
   }
+
+  .user_info_links.is-open {
+    display: flex;
+    flex-direction: column;
+  }
   
 
   
@@ -213,7 +218,6 @@ header {
   }
   
   .notification_hover {
-
     position: absolute;
     transform: translateX(85%);
     top: 150%;
@@ -229,6 +233,10 @@ header {
     gap: 8px;
     z-index: 50;
     transition: opacity 0.3s ease;
+  }
+
+  .notification_hover.is-open {
+    display: flex;
   }
   
 

--- a/header-toggle-demo.html
+++ b/header-toggle-demo.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>آزمایش دکمه‌های هدر</title>
+    <link rel="stylesheet" href="css/colors.css" />
+    <link rel="stylesheet" href="css/header.css" />
+    <link rel="stylesheet" href="fonts/fonts.css" />
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(135deg, #0f172a, #1f2937);
+        font-family: "IRANSans", sans-serif;
+      }
+
+      .demo-wrapper {
+        background-color: rgba(15, 23, 42, 0.85);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 20px;
+        padding: 40px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        color: var(--white-color, #fff);
+        box-shadow: 0 30px 60px rgba(15, 23, 42, 0.4);
+      }
+
+      .demo-title {
+        font-size: 20px;
+        text-align: center;
+        font-weight: 600;
+      }
+
+      .demo-note {
+        font-size: 14px;
+        text-align: center;
+        line-height: 1.8;
+        color: rgba(255, 255, 255, 0.75);
+      }
+
+      .demo-controls {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 24px;
+      }
+
+      .user_islogin_to_register {
+        background: rgba(15, 23, 42, 0.5);
+        border-radius: 16px;
+        padding: 24px;
+        border: 1px solid rgba(255, 255, 255, 0.05);
+      }
+
+      .wallet_info span {
+        font-size: 14px;
+      }
+
+      .notification_hover,
+      .user_info_links {
+        box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="demo-wrapper">
+      <div class="demo-title">آزمایش باز و بسته شدن منوهای هدر</div>
+      <div class="demo-note">
+        روی آیکن‌های کاربر و اعلان کلیک کنید تا باز و بسته شدن منوها را
+        مشاهده کنید. کلیک در بیرون از منو باعث بسته شدن هر دو می‌شود.
+      </div>
+      <div class="demo-controls">
+        <div class="user_islogin_to_register">
+          <div class="wallet_info" role="status">
+            <span>موجودی: ۱۲٬۰۰۰٬۰۰۰ تومان</span>
+            <img src="img/icons/wallet.svg" alt="wallet" />
+          </div>
+          <div class="user-menu-wrapper">
+            <button
+              class="open_user_links"
+              aria-haspopup="true"
+              aria-expanded="false"
+              aria-controls="userMenu"
+              type="button"
+            >
+              <img src="img/icons/user-icon.svg" alt="user" width="20" />
+            </button>
+            <div class="user_info_links" id="userMenu" role="menu" tabindex="-1">
+              <div class="link_item" role="menuitem">
+                <a href="#">
+                  <img src="img/icons/user-icon.svg" alt="dashboard" width="14" />
+                  <span>داشبورد</span>
+                </a>
+              </div>
+              <div class="link_item" role="menuitem">
+                <a href="#">
+                  <img src="img/icons/wallet.svg" alt="wallet" width="14" />
+                  <span>کیف پول من</span>
+                </a>
+              </div>
+              <div class="link_item" role="menuitem">
+                <a href="#">
+                  <img src="img/icons/exit.svg" alt="logout" width="14" />
+                  <span>خروج</span>
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="notification_bar">
+            <button
+              class="notification"
+              aria-haspopup="true"
+              aria-expanded="false"
+              aria-controls="notifMenu"
+              type="button"
+            >
+              <img src="img/icons/notification.svg" alt="notification" />
+            </button>
+            <div
+              class="notification_hover"
+              id="notifMenu"
+              role="menu"
+              tabindex="-1"
+            >
+              <div class="notification_title">
+                <img src="img/icons/edit.svg" alt="notifications" />
+                <span>اعلان‌ها</span>
+              </div>
+              <div class="message_notification">
+                <div class="notification_username">
+                  <span>سیستم</span>
+                </div>
+                <div class="user_message">
+                  <span>حساب شما با موفقیت فعال شد.</span>
+                </div>
+              </div>
+              <hr />
+              <div class="sea_all_notifacation">
+                <a href="#">مشاهده همه اعلان‌ها</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        const userButton = document.querySelector('.open_user_links');
+        const userMenu = document.querySelector('.user_info_links');
+        const notifButton = document.querySelector('.notification');
+        const notifMenu = document.querySelector('.notification_hover');
+
+        function toggleMenu(menuToToggle, otherMenu, trigger, otherTrigger) {
+          if (!menuToToggle) return;
+
+          const isOpen = menuToToggle.classList.toggle('is-open');
+
+          if (trigger) {
+            trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+          }
+
+          if (otherMenu) {
+            otherMenu.classList.remove('is-open');
+          }
+
+          if (otherTrigger) {
+            otherTrigger.setAttribute('aria-expanded', 'false');
+          }
+        }
+
+        function closeMenus() {
+          if (userMenu) {
+            userMenu.classList.remove('is-open');
+          }
+          if (notifMenu) {
+            notifMenu.classList.remove('is-open');
+          }
+          if (userButton) {
+            userButton.setAttribute('aria-expanded', 'false');
+          }
+          if (notifButton) {
+            notifButton.setAttribute('aria-expanded', 'false');
+          }
+        }
+
+        if (userButton) {
+          userButton.addEventListener('click', function (event) {
+            event.stopPropagation();
+            toggleMenu(userMenu, notifMenu, userButton, notifButton);
+          });
+        }
+
+        if (notifButton) {
+          notifButton.addEventListener('click', function (event) {
+            event.stopPropagation();
+            toggleMenu(notifMenu, userMenu, notifButton, userButton);
+          });
+        }
+
+        if (userMenu) {
+          userMenu.addEventListener('click', function (event) {
+            event.stopPropagation();
+          });
+        }
+
+        if (notifMenu) {
+          notifMenu.addEventListener('click', function (event) {
+            event.stopPropagation();
+          });
+        }
+
+        document.addEventListener('click', closeMenus);
+      })();
+    </script>
+  </body>
+</html>

--- a/js/header.js
+++ b/js/header.js
@@ -85,51 +85,69 @@ function initHeaderAndSidebar() {
   const notifButton = document.querySelector(".notification");
   const notifMenu = document.querySelector(".notification_hover");
 
-  if (userMenu) userMenu.style.display = "none";
-  if (notifMenu) notifMenu.style.display = "none";
+  const toggleMenu = (menuToToggle, otherMenu, trigger, otherTrigger) => {
+    if (!menuToToggle) return;
 
-  function toggleMenu(menuToToggle, otherMenu) {
-      if (menuToToggle && menuToToggle.style.display === "none") {
-          // Close other menu
-          if (otherMenu) otherMenu.style.display = "none";
-          // Open target menu
-          menuToToggle.style.display = "block";
-      } else if (menuToToggle) {
-          menuToToggle.style.display = "none";
-      }
-  }
+    const isOpen = menuToToggle.classList.toggle("is-open");
 
-  // Click user button
-  if (userButton) {
-    userButton.addEventListener("click", function(e) {
-        e.stopPropagation(); // Prevent closing menu on document click
-        toggleMenu(userMenu, notifMenu);
-    });
-  }
+    if (trigger) {
+      trigger.setAttribute("aria-expanded", isOpen ? "true" : "false");
+    }
 
-  // Click notification button
-  if (notifButton) {
-    notifButton.addEventListener("click", function(e) {
+    if (otherMenu) {
+      otherMenu.classList.remove("is-open");
+    }
+
+    if (otherTrigger) {
+      otherTrigger.setAttribute("aria-expanded", "false");
+    }
+  };
+
+  const closeMenus = () => {
+    if (userMenu) userMenu.classList.remove("is-open");
+    if (notifMenu) notifMenu.classList.remove("is-open");
+    if (userButton) userButton.setAttribute("aria-expanded", "false");
+    if (notifButton) notifButton.setAttribute("aria-expanded", "false");
+  };
+
+  // Always ensure menus start in a closed state on each init call
+  closeMenus();
+
+  const menusReady = userButton || notifButton;
+
+  if (!window.__headerMenuEventsBound && menusReady) {
+    if (userButton) {
+      userButton.addEventListener("click", function(e) {
         e.stopPropagation();
-        toggleMenu(notifMenu, userMenu);
-    });
-  }
+        toggleMenu(userMenu, notifMenu, userButton, notifButton);
+      });
+    }
 
-  // Click outside menus closes them
-  document.addEventListener("click", function() {
-      if (userMenu) userMenu.style.display = "none";
-      if (notifMenu) notifMenu.style.display = "none";
-  });
+    if (notifButton) {
+      notifButton.addEventListener("click", function(e) {
+        e.stopPropagation();
+        toggleMenu(notifMenu, userMenu, notifButton, userButton);
+      });
+    }
 
-  // Prevent closing menu when clicking inside menus
-  if (userMenu) {
-    userMenu.addEventListener("click", function(e) {
+    document.addEventListener("click", closeMenus);
+
+    if (userMenu) {
+      userMenu.addEventListener("click", function(e) {
         e.stopPropagation();
-    });
-  }
-  if (notifMenu) {
-    notifMenu.addEventListener("click", function(e) {
+      });
+    }
+
+    if (notifMenu) {
+      notifMenu.addEventListener("click", function(e) {
         e.stopPropagation();
-    });
+      });
+    }
+
+    window.__headerMenuEventsBound = true;
+    window.__headerCloseMenus = closeMenus;
+  } else if (typeof window.__headerCloseMenus === "function") {
+    // Subsequent calls should still collapse any open state without re-binding listeners
+    window.__headerCloseMenus();
   }
 }


### PR DESCRIPTION
## Summary
- guard the header menu setup so repeated `initHeaderAndSidebar` calls (for example from footer.js) no longer attach duplicate click handlers
- centralize menu closing logic to reset aria-expanded state on every init call while keeping the menus closed by default

## Testing
- manual Playwright verification of user and notification menu toggles on index.html and tournaments.html

------
https://chatgpt.com/codex/tasks/task_b_68ce829c86f483228c65f9cefcf0663b